### PR TITLE
Remove leftover code that is causing a PHP notice error

### DIFF
--- a/core/components/archivist/model/archivist/archivist.class.php
+++ b/core/components/archivist/model/archivist/archivist.class.php
@@ -141,7 +141,6 @@ class Archivist {
             unset($getParams[$this->modx->getOption('request_param_alias',null,'q')],$getParams[$prefix.'year'],$getParams[$prefix.'month'],$getParams[$prefix.'day']);
         } else { $getParams = array(); }
 
-        $array = is_string($array) ? explode('&',$array) : $array;
         if (is_string($array)) {
             $array = empty($array) ? array() : explode('&',$array);
         }


### PR DESCRIPTION
The `if` block that follows the removed line does the same thing as that line, but without generating a PHP notice. Looks like the original line was left in by accident.
