### PR TITLE
Added Span for (count)

### DIFF
--- a/core/components/archivist/elements/chunks/row.chunk.tpl
+++ b/core/components/archivist/elements/chunks/row.chunk.tpl
@@ -1,3 +1,3 @@
 <li class="[[+cls]]">
-    <a href="[[+url]]" title="[[+date]]">[[+date]]</a> ([[+count]])
+    <a href="[[+url]]" title="[[+date]]">[[+date]]</a> <span class="count">([[+count]])</span>
 </li>


### PR DESCRIPTION
Wrapped the count displayed in parenthesis in row.chunk.tpl with a span.count so that it can easily be styled or hidden with CSS.

Please let me know if there's anything I can do with this request.

Signed-off-by: JP DeVries johnpaul.devries@gmail.com
