### PR TITLE
Add check to only search the alias map if it's an array.

### DIFF
--- a/core/components/archivist/elements/plugins/plugin.archivistfurl.php
+++ b/core/components/archivist/elements/plugins/plugin.archivistfurl.php
@@ -47,11 +47,13 @@ $prefix = 'arc_';
 foreach ($archiveIds as $archive) {
     $archive = explode(':',$archive);
     $archiveId = $archive[0];
-    $alias = array_search($archiveId,$modx->aliasMap);
-    if ($alias && strpos($search,$alias) !== false) {
-        $search = str_replace($alias,'',$search);
-        $resourceId = $archiveId;
-        if (isset($archive[1])) $prefix = $archive[1];
+    if(is_array($modx->aliasMap)) {
+        $alias = array_search($archiveId,$modx->aliasMap);
+        if ($alias && strpos($search,$alias) !== false) {
+            $search = str_replace($alias,'',$search);
+            $resourceId = $archiveId;
+            if (isset($archive[1])) $prefix = $archive[1];
+        }
     }
 }
 if (!$resourceId) return;


### PR DESCRIPTION
This will stop the plugin from generating warnings if the alias map is not an array.
